### PR TITLE
feat: consider bank holiday for the Coronation of King Charles III

### DIFF
--- a/gb.yaml
+++ b/gb.yaml
@@ -65,6 +65,11 @@ months:
     wday: 1
     year_ranges:
       from: 2021
+  - name: Bank Holiday for the Coronation of King Charles III
+    regions: [gb]
+    mday: 8
+    year_ranges:
+      limited: [ 2023 ]
   - name: Liberation Day
     regions: [je, gb_jsy, gg, gb_gsy]
     mday: 9
@@ -526,6 +531,21 @@ tests:
   - given:
       date: '2021-09-19'
       regions: ['gb']
+    expect:
+      holiday: false
+  - given:
+      date: '2023-05-08'
+      regions: ["gb"]
+    expect:
+      name: "Bank Holiday for the Coronation of King Charles III"
+  - given:
+      date: '2024-05-08'
+      regions: ["gb"]
+    expect:
+      holiday: false
+  - given:
+      date: '2022-05-08'
+      regions: ["gb"]
     expect:
       holiday: false
   - given:


### PR DESCRIPTION
## What does this PR do?
On the 8th of May 2023, there will be a bank holiday for the Coronation of King Charles III.

<kbd><img width="607" alt="image" src="https://user-images.githubusercontent.com/11311824/236448975-058bee75-c983-49df-becb-21860bcfa0c1.png"></kbd>

## External context (JIRA)
[PHEALTH-997](https://seedrs.atlassian.net/browse/PHEALTH-997)

## Deploy plan
Merge with master


[PHEALTH-997]: https://seedrs.atlassian.net/browse/PHEALTH-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ